### PR TITLE
allow to pass custom class name to style AuthButton component

### DIFF
--- a/src/components/LoginButton.jsx
+++ b/src/components/LoginButton.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import auth from 'solid-auth-client';
 
 /** Button that lets the user log in with Solid. */
-export default function LoginButton({ popup, className }) {
+export default function LoginButton({ popup, className = 'solid auth login' }) {
   return <button
-    className={`solid auth login ${className}`}
+    className={className}
     onClick={() => auth.popupLogin({ popupUri: popup })}>Log in</button>;
 }

--- a/src/components/LoginButton.jsx
+++ b/src/components/LoginButton.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import auth from 'solid-auth-client';
 
 /** Button that lets the user log in with Solid. */
-export default function LoginButton({ popup }) {
+export default function LoginButton({ popup, className }) {
   return <button
-    className="solid auth login"
+    className={`solid auth login ${className}`}
     onClick={() => auth.popupLogin({ popupUri: popup })}>Log in</button>;
 }

--- a/src/components/LogoutButton.jsx
+++ b/src/components/LogoutButton.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import auth from 'solid-auth-client';
 
 /** Button that lets the user log out with Solid. */
-export default function LogoutButton() {
+export default function LogoutButton({ className }) {
   return <button
-    className="solid auth logout"
+    className={`solid auth logout ${className}`}
     onClick={() => auth.logout()}>Log out</button>;
 }

--- a/src/components/LogoutButton.jsx
+++ b/src/components/LogoutButton.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import auth from 'solid-auth-client';
 
 /** Button that lets the user log out with Solid. */
-export default function LogoutButton({ className }) {
+export default function LogoutButton({ className = 'solid auth logout' }) {
   return <button
-    className={`solid auth logout ${className}`}
+    className={className}
     onClick={() => auth.logout()}>Log out</button>;
 }

--- a/test/components/AuthButton-test.jsx
+++ b/test/components/AuthButton-test.jsx
@@ -5,7 +5,7 @@ import auth from 'solid-auth-client';
 
 describe('An AuthButton', () => {
   let button;
-  beforeAll(() => (button = mount(<AuthButton/>)));
+  beforeAll(() => (button = mount(<AuthButton className="custom styling"/>)));
   afterAll(() => button.unmount());
 
   describe('when the user is not logged in', () => {
@@ -14,6 +14,10 @@ describe('An AuthButton', () => {
     it('renders the log in button', () => {
       expect(button.text()).toBe('Log in');
     });
+
+    it('respects custom styling in button class name', () => {
+      expect(button.find('button').prop('className')).toEqual('solid auth login custom styling');
+    });
   });
 
   describe('renders the log out button', () => {
@@ -21,6 +25,10 @@ describe('An AuthButton', () => {
 
     it('has "Log out" as text', () => {
       expect(button.text()).toBe('Log out');
+    });
+
+    it('respects custom styling in button class name', () => {
+      expect(button.find('button').prop('className')).toEqual('solid auth login custom styling');
     });
   });
 });

--- a/test/components/AuthButton-test.jsx
+++ b/test/components/AuthButton-test.jsx
@@ -4,31 +4,55 @@ import { mount } from 'enzyme';
 import auth from 'solid-auth-client';
 
 describe('An AuthButton', () => {
-  let button;
-  beforeAll(() => (button = mount(<AuthButton className="custom styling"/>)));
-  afterAll(() => button.unmount());
+  describe('default', function () {
+    let button;
+    beforeEach(() => (button = mount(<AuthButton />)));
+    afterEach(() => button.unmount());
 
-  describe('when the user is not logged in', () => {
-    beforeAll(() => auth.mockWebId(null));
+    describe('when the user is not logged in', () => {
+      beforeAll(() => auth.mockWebId(null));
 
-    it('renders the log in button', () => {
-      expect(button.text()).toBe('Log in');
+      it('renders the log in button', () => {
+        expect(button.text()).toBe('Log in');
+      });
+
+      it('uses default class names', () => {
+        expect(button.find('button').prop('className')).toEqual('solid auth login');
+      });
     });
 
-    it('respects custom styling in button class name', () => {
-      expect(button.find('button').prop('className')).toEqual('solid auth login custom styling');
+    describe('renders the log out button', () => {
+      beforeAll(() => auth.mockWebId('https://example.org/#me'));
+
+      it('has "Log out" as text', () => {
+        expect(button.text()).toBe('Log out');
+      });
+
+      it('uses default class names', () => {
+        expect(button.find('button').prop('className')).toEqual('solid auth logout');
+      });
     });
   });
 
-  describe('renders the log out button', () => {
-    beforeAll(() => auth.mockWebId('https://example.org/#me'));
+  describe('custom class names', function () {
+    let button;
+    beforeEach(() => (button = mount(<AuthButton className="custom styling"/>)));
+    afterEach(() => button.unmount());
 
-    it('has "Log out" as text', () => {
-      expect(button.text()).toBe('Log out');
+    describe('when the user is not logged in', () => {
+      beforeAll(() => auth.mockWebId(null));
+
+      it('respects custom styling in button class name', () => {
+        expect(button.find('button').prop('className')).toEqual('custom styling');
+      });
     });
 
-    it('respects custom styling in button class name', () => {
-      expect(button.find('button').prop('className')).toEqual('solid auth login custom styling');
+    describe('renders the log out button', () => {
+      beforeAll(() => auth.mockWebId('https://example.org/#me'));
+
+      it('respects custom styling in button class name', () => {
+        expect(button.find('button').prop('className')).toEqual('custom styling');
+      });
     });
   });
 });


### PR DESCRIPTION
<!-- Thanks for helping out! Following this template lets us respond faster. -->

### Kind of change
<!-- Check at least one. Update "[ ]" to "[x]" to check a box -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Proposed changes

This PR enables to add a custom className property to the AuthButton component to be able to apply styling to the login / logout button. This is e.g. necessary when using frameworks like material-ui which apply their own style names. Those where not passed to the underlying DOM `<button />`, which is now fixed by this PR.

### Relevant issues
<!--
- https://github.com/solid/react-components/issues/XXX
-->

### Breaking change?
<!-- Check one. -->
- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path. -->

### Requirements check

- [X] All tests are passing
- [X] New/updated tests are included

### Additional info
<!-- Optionally add any other info or context here. -->
