### PR TITLE
Support LDflex expressions resulting in unthenable.

### DIFF
--- a/src/ExpressionEvaluator.js
+++ b/src/ExpressionEvaluator.js
@@ -107,13 +107,16 @@ export default class ExpressionEvaluator {
     return true;
   }
 
-  /** Resolves the property into an LDflex path. */
+  /** Resolves the expression into an LDflex path. */
   resolveExpression(expr) {
-    // If the property is an LDflex string expression, resolve it
+    // Ignore an empty expression
     if (!expr)
       return '';
-    const resolved = typeof expr === 'string' ? data.resolve(expr) : expr;
-
-    return resolved;
+    // Resolve an LDflex string expression
+    else if (typeof expr === 'string')
+      return data.resolve(expr);
+    // Return a resolved LDflex path (and any other object) as-is
+    else
+      return expr;
   }
 }

--- a/src/ExpressionEvaluator.js
+++ b/src/ExpressionEvaluator.js
@@ -56,8 +56,9 @@ export default class ExpressionEvaluator {
   /** Evaluates the property expression as a singular value. */
   async evaluateAsValue(key, expr, updateCallback) {
     // Obtain and await the promise
-    const promise = this.resolveExpression(key, expr, 'then');
+    const promise = this.resolveExpression(expr);
     this.pending[key] = promise;
+
     try {
       const value = await promise;
       // Stop if another evaluator took over in the meantime (component update)
@@ -76,7 +77,7 @@ export default class ExpressionEvaluator {
   /** Evaluates the property expression as a list. */
   async evaluateAsList(key, expr, updateCallback) {
     // Create the iterable
-    const iterable = this.resolveExpression(key, expr, Symbol.asyncIterator);
+    const iterable = this.resolveExpression(expr);
     if (!iterable)
       return true;
     this.pending[key] = iterable;
@@ -107,15 +108,11 @@ export default class ExpressionEvaluator {
   }
 
   /** Resolves the property into an LDflex path. */
-  resolveExpression(key, expr, expectedProperty) {
+  resolveExpression(expr) {
     // If the property is an LDflex string expression, resolve it
     if (!expr)
       return '';
     const resolved = typeof expr === 'string' ? data.resolve(expr) : expr;
-
-    // Ensure that the resolved value is an LDflex path
-    if (!resolved || typeof resolved[expectedProperty] !== 'function')
-      throw new Error(`${key} should be an LDflex path or string but is ${expr}`);
 
     return resolved;
   }

--- a/test/components/evaluateExpressions-test.jsx
+++ b/test/components/evaluateExpressions-test.jsx
@@ -38,18 +38,25 @@ describe('An evaluateExpressions wrapper', () => {
     render(<Component/>);
   });
 
-  it('accepts non-LDflex types as valueProps and listProps', async () => {
-    const Component = evaluateExpressions(['a'], ['b'], () => null);
-    render(<Component a={1234} b={[1, 2, 3, 4]} />);
-  });
+  it('accepts objects as valueProps and listProps', async () => {
+    const Component = evaluateExpressions(['a'], ['b'], ({ a, b }) =>
+      <span data-a={`${a}`} data-b={`${b.length}`}/>);
 
-  it('accepts LDFlex expression which results in unthenable as valueProps and listProps', async () => {
-    data.resolve.mockReturnValue(1234);
-    const Component = evaluateExpressions(['a'], ({ a }) => <span data-a={`${a}`}/>);
-
-    const rendered = render(<Component a="[unthenable expression for value]"/>);
+    const rendered = render(<Component a={1234} b={[1, 2, 3, 4]} />);
     await waitForDomChange();
     expect(rendered.container.firstChild).toHaveAttribute('data-a', '1234');
+    expect(rendered.container.firstChild).toHaveAttribute('data-b', '4');
+  });
+
+  it('accepts an LDFlex expression resulting in a regular object as valueProps and listProps', async () => {
+    data.resolve.mockReturnValue(1234);
+    const Component = evaluateExpressions(['a'], ['b'], ({ a, b }) =>
+      <span data-a={`${a}`} data-b={`${b.length}`}/>);
+
+    const rendered = render(<Component a="[path]"/>);
+    await waitForDomChange();
+    expect(rendered.container.firstChild).toHaveAttribute('data-a', '1234');
+    expect(rendered.container.firstChild).toHaveAttribute('data-b', '0');
   });
 
   it('accepts empty properties', async () => {

--- a/test/components/evaluateExpressions-test.jsx
+++ b/test/components/evaluateExpressions-test.jsx
@@ -38,6 +38,20 @@ describe('An evaluateExpressions wrapper', () => {
     render(<Component/>);
   });
 
+  it('accepts non-LDflex types as valueProps and listProps', async () => {
+    const Component = evaluateExpressions(['a'], ['b'], () => null);
+    render(<Component a={1234} b={[1, 2, 3, 4]} />);
+  });
+
+  it('accepts LDFlex expression which results in unthenable as valueProps and listProps', async () => {
+    data.resolve.mockReturnValue(1234);
+    const Component = evaluateExpressions(['a'], ({ a }) => <span data-a={`${a}`}/>);
+
+    const rendered = render(<Component a="[unthenable expression for value]"/>);
+    await waitForDomChange();
+    expect(rendered.container.firstChild).toHaveAttribute('data-a', '1234');
+  });
+
   it('accepts empty properties', async () => {
     const Component = evaluateExpressions(['a'], ['b'],
       ({ error }) => <span data-error={`${error}`}/>);
@@ -45,15 +59,6 @@ describe('An evaluateExpressions wrapper', () => {
     await expect(waitForDomChange({ timeout: 50 })).rejects.toThrow();
 
     expect(wrapped()).toHaveAttribute('data-error', 'undefined');
-  });
-
-  it('errors on invalid expression types', async () => {
-    const Component = evaluateExpressions(['a'], ({ error }) => `${error}`);
-    ({ container } = render(<Component a={1234}/>));
-    await waitForDomChange();
-
-    expect(container).toHaveTextContent(
-      'Error: a should be an LDflex path or string but is 1234');
   });
 
   describe('before properties are resolved', () => {


### PR DESCRIPTION

### Kind of change
<!-- Check at least one. Update "[ ]" to "[x]" to check a box -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Proposed changes
This fixation can actually eliminate error described in #12 but I doubt if its result is what you expect.


### Relevant issues
https://github.com/solid/react-components/issues/12


### Breaking change?
<!-- Check one. -->
- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path. -->

### Requirements check

- [x] All tests are passing
- [x] New/updated tests are included

### Additional info


This fixation can actually eliminate the above error but I doubt if its result is what you expect.

For example,
```jsx
<Value src="[https://ruben.verborgh.org/profile/#me]"/>
```

Rendered as 
```html
"https://ruben.verborgh.org/profile/#me"
```

Any comments and suggestion will be appreciated.



